### PR TITLE
Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,19 @@ repository = "https://github.com/stellar-scaffold/cli"
 version = "0.0.1"
 
 [workspace.dependencies.soroban-sdk]
-version = "23.4.0"
+version = "26.1.0"
 
 [workspace.dependencies.stellar-access]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.6.0"
+tag = "v0.7.2"
 
 [workspace.dependencies.stellar-macros]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.6.0"
+tag = "v0.7.2"
 
 [workspace.dependencies.stellar-tokens]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.6.0"
+tag = "v0.7.2"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/guess-the-number/Cargo.toml
+++ b/contracts/guess-the-number/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "23.0.3"
+soroban-sdk = { workspace = true }
 stellar-registry = "0.0.4"
 
 [dev-dependencies]
 stellar-xdr = { version = "23.0.0", features = ["curr", "serde"] }
-soroban-sdk = { version = "23.0.3", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.93.0"
 targets = ["wasm32v1-none"]


### PR DESCRIPTION
- updated the rust version to 1.93 - in the workflow of getting started with scaffold & registry, I wasn't able to install registry with the current rust version in rust-toolchain.toml.
- updated the oz/stellar-contract deps to their most recent v0.7.2
- updated soroban-sdk to the most recent that the oz repo supports - 26.1.0
- updated the guess-the-number to use the workspace version of soroban-sdk