### PR TITLE
fix(ci): pin rustc 1.93.0 and lock binstall source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,11 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      # Pin rustc to the CLI's required toolchain (see cli/rust-toolchain.toml).
+      # Without this, the "released, fast" binstall fallback below compiles
+      # against the runner's stale default rustc and fails on soroban-cli's
+      # MSRV bump.
+      - run: rustup toolchain install 1.93.0 && rustup default 1.93.0
       # Add the wasm32v1-none target for building contracts
       - run: rustup target add wasm32v1-none
       - run:
@@ -74,7 +79,10 @@ jobs:
         run: |
           if ! command -v stellar-scaffold &> /dev/null; then
             echo "stellar-scaffold not found, installing..."
-            cargo binstall stellar-scaffold-cli
+            # --locked so the source-build fallback uses the CLI's published
+            # Cargo.lock instead of resolving fresh soroban deps whose MSRV
+            # may outrun the pinned toolchain.
+            cargo binstall --locked stellar-scaffold-cli
           else
             echo "stellar-scaffold already installed. Clear cache to force reinstall."
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,13 +43,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      # Pin rustc to the CLI's required toolchain (see cli/rust-toolchain.toml).
-      # Without this, the "released, fast" binstall fallback below compiles
-      # against the runner's stale default rustc and fails on soroban-cli's
-      # MSRV bump.
-      - run: rustup toolchain install 1.93.0 && rustup default 1.93.0
-      # Add the wasm32v1-none target for building contracts
-      - run: rustup target add wasm32v1-none
       - run:
           sudo apt-get update && sudo apt-get install -y libudev-dev
           libdbus-1-dev pkg-config

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.93.0"
 targets = ["wasm32v1-none"]


### PR DESCRIPTION
cargo-binstall as a fallback compiled stellar-scaffold-cli with runner's default rustc 1.89.0 which pulled soroban-cli 27.0.0, failing the build on main. Pin the toolchain to match cli/rust-toolchain.toml and pass `--locked` to binstall.