### PR TITLE
Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,19 @@ repository = "https://github.com/stellar-scaffold/cli"
 version = "0.0.1"
 
 [workspace.dependencies.soroban-sdk]
-version = "23.4.0"
+version = "26.1.0"
 
 [workspace.dependencies.stellar-access]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.6.0"
+tag = "v0.7.2"
 
 [workspace.dependencies.stellar-macros]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.6.0"
+tag = "v0.7.2"
 
 [workspace.dependencies.stellar-tokens]
 git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.6.0"
+tag = "v0.7.2"
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,13 @@ license = "Apache-2.0"
 repository = "https://github.com/stellar-scaffold/cli"
 version = "0.0.1"
 
-[workspace.dependencies.soroban-sdk]
-version = "26.1.0"
-
-[workspace.dependencies.stellar-access]
-git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.7.2"
-
-[workspace.dependencies.stellar-macros]
-git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.7.2"
-
-[workspace.dependencies.stellar-tokens]
-git = "https://github.com/OpenZeppelin/stellar-contracts"
-tag = "v0.7.2"
+[workspace.dependencies]
+soroban-sdk = "26.1.0"
+stellar-access = "0.7.2"
+stellar-macros = "0.7.2"
+stellar-tokens = "0.7.2"
+stellar-registry = "0.0.11"
+stellar-xdr = "26.0.1"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/fungible-allowlist/src/test.rs
+++ b/contracts/fungible-allowlist/src/test.rs
@@ -1,6 +1,6 @@
 extern crate std;
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 use crate::contract::{ExampleContract, ExampleContractClient};
 
@@ -10,7 +10,9 @@ fn create_client<'a>(
     manager: &Address,
     initial_supply: &i128,
 ) -> ExampleContractClient<'a> {
-    let address = e.register(ExampleContract, (admin, manager, initial_supply));
+    let name = String::from_str(e, "AllowList Token");
+    let symbol = String::from_str(e, "ALT");
+    let address = e.register(ExampleContract, (name, symbol, admin, manager, initial_supply));
     ExampleContractClient::new(e, &address)
 }
 

--- a/contracts/guess-the-number/Cargo.toml
+++ b/contracts/guess-the-number/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "23.0.3"
+soroban-sdk = { workspace = true }
 stellar-registry = "0.0.4"
 
 [dev-dependencies]
 stellar-xdr = { version = "23.0.0", features = ["curr", "serde"] }
-soroban-sdk = { version = "23.0.3", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/guess-the-number/Cargo.toml
+++ b/contracts/guess-the-number/Cargo.toml
@@ -17,8 +17,8 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-stellar-registry = "0.0.4"
+stellar-registry = { workspace = true }
 
 [dev-dependencies]
-stellar-xdr = { version = "23.0.0", features = ["curr", "serde"] }
+stellar-xdr = { workspace = true, features = ["curr", "serde"] }
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/nft-enumerable/src/test.rs
+++ b/contracts/nft-enumerable/src/test.rs
@@ -1,11 +1,14 @@
 extern crate std;
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 use crate::contract::{ExampleContract, ExampleContractClient};
 
 fn create_client<'a>(e: &Env, owner: &Address) -> ExampleContractClient<'a> {
-    let address = e.register(ExampleContract, (owner,));
+    let uri = String::from_str(e, "www.mytoken.com");
+    let name = String::from_str(e, "My Token");
+    let symbol = String::from_str(e, "TKN");
+    let address = e.register(ExampleContract, (uri, name, symbol, owner));
     ExampleContractClient::new(e, &address)
 }
 
@@ -28,13 +31,48 @@ fn enumerable_transfer_override_works() {
 }
 
 #[test]
-fn enumerable_burn_works() {
+fn enumerable_transfer_from_override_works() {
+    let e = Env::default();
+
+    let owner = Address::generate(&e);
+    let spender = Address::generate(&e);
+    let recipient = Address::generate(&e);
+
+    let client = create_client(&e, &owner);
+
+    e.mock_all_auths();
+    client.mint(&owner);
+    client.approve(&owner, &spender, &0, &1000);
+    client.transfer_from(&spender, &owner, &recipient, &0);
+    assert_eq!(client.balance(&owner), 0);
+    assert_eq!(client.balance(&recipient), 1);
+    assert_eq!(client.get_owner_token_id(&recipient, &0), 0);
+}
+
+#[test]
+fn enumerable_burn_override_works() {
     let e = Env::default();
     let owner = Address::generate(&e);
     let client = create_client(&e, &owner);
     e.mock_all_auths();
     client.mint(&owner);
     client.burn(&owner, &0);
+    assert_eq!(client.balance(&owner), 0);
+    client.mint(&owner);
+    assert_eq!(client.balance(&owner), 1);
+    assert_eq!(client.get_owner_token_id(&owner, &0), 1);
+}
+
+#[test]
+fn enumerable_burn_from_override_works() {
+    let e = Env::default();
+    let owner = Address::generate(&e);
+    let spender = Address::generate(&e);
+    let client = create_client(&e, &owner);
+    e.mock_all_auths();
+    client.mint(&owner);
+    client.approve(&owner, &spender, &0, &1000);
+    client.burn_from(&spender, &owner, &0);
     assert_eq!(client.balance(&owner), 0);
     client.mint(&owner);
     assert_eq!(client.balance(&owner), 1);


### PR DESCRIPTION
Fork of @elizabethengelman's https://github.com/stellar-scaffold/ui/pull/248 rebased on latest `main` to fix GH build

- updated the rust version to 1.93 - in the workflow of getting started with scaffold & registry, I wasn't able to install registry with the current rust version in rust-toolchain.toml.
- updated the oz/stellar-contract deps to their most recent v0.7.2
- updated the oz contracts with `stellar scaffold generate`
- updated soroban-sdk to the most recent that the oz repo supports - 26.1.0 (see https://github.com/OpenZeppelin/stellar-contracts/issues/796 for issue tracking update to p27)
- updated the guess-the-number to use the workspace version of soroban-sdk
- moved all deps to root Cargo.toml