### PR TITLE
docs: clarify doc comment on `getWalletNetwork`

### DIFF
--- a/app-lib/wallet.ts
+++ b/app-lib/wallet.ts
@@ -35,8 +35,12 @@ export const signTransaction = StellarWalletsKit.signTransaction
 
 /**
  * Use the wallet's reported network if it supports it, otherwise flag the
- * wallet as unsupported and try transactions anyways, falling back to error
- * parsing to determine a network mismatch in case of problems.
+ * wallet as unsupported. Note that even if a wallet is `unsupported`, this
+ * only means it does not support the `getNetwork` function. It *may* still
+ * support passing `networkPassphrase` to `signTransaction`. For the wallets
+ * that do not support the `networkPassphrase` argument to `signTransaction`,
+ * you can fall back to error parsing to determine if `signTransaction`
+ * failures were due to network mismatch.
  */
 export const getWalletNetwork = async (): Promise<{
 	supported: boolean


### PR DESCRIPTION
The way I read this doc comment, it is _describing itself_ and saying that _it_ will call `signTransaction` and fall back to error parsing. But I _think_ it's trying to tell the _consumer_ that _they_ can do these things. This clarifies the comment.

Original discussion: https://github.com/stellar-scaffold/ui/pull/241#discussion_r3640353130