### PR TITLE
feat: proper GH release for guess-the-number wasm

### DIFF
--- a/.github/workflows/contract-release.yml
+++ b/.github/workflows/contract-release.yml
@@ -1,9 +1,25 @@
-name: Publish contracts
+# This job creates a GitHub Release for the guess-the-number contract:
+#
+# - Add `source_repo` & `home_domain` metadata to wasm
+# - Publish `.wasm` file to GH Release
+# - Post build info to https://stellar.expert (SEP-55)
+#
+# After the GH Release is complete, you can download the `.wasm` file from GH
+# and use `stellar contract upload` to get that wasm on-chain, or `stellar
+# registry publish` to both get it on-chain and give it a name/version via
+# Stellar Registry.
+name: "GH Release: guess-the-number"
 
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: "Release name (e.g. v1.0.0)"
+        required: true
+        type: string
 
 permissions: # required permissions for the workflow
   id-token: write
@@ -15,14 +31,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Environment gate (proper sandboxing workaround for stellar-expert/soroban-build-workflow, which lacks it)
+  approve-release:
+    runs-on: ubuntu-latest
+    environment: publish-contract # ← adds the environment isolation (sandboxing)
+    permissions: {}
+    steps:
+      - run: echo "Approved release"
+
   release-contract:
+    needs: approve-release # ← makes this job depend on the environment gate
     name: Compile Stellar smart contract for production and create release
-    uses: stellar-expert/soroban-build-workflow/.github/workflows/release.yml@2ff8e0a5a122981b534bfc76851d26d74905c1cc
+    uses: stellar-expert/soroban-build-workflow/.github/workflows/release.yml@88068ec50cba931a96436869727ed08edeb76ade
     with:
       release_name: ${{ github.ref_name }}
-      release_description: "Scaffold contract release"
-      home_domain: "your-domain.dev"
-      relative_path: "contracts/..."
-      package: "..."
+      release_description: "Release ${{ github.ref_name }}"
+      home_domain: "stellarscaffold.org"
+      relative_path: "contracts/guess-the-number"
+      package: "guess-the-number"
     secrets:
       release_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ authors = ["The Aha Company"]
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/stellar-scaffold/cli"
-version = "0.0.1"
+version = "0.0.2"
 
 [workspace.dependencies]
 soroban-sdk = "26.1.0"
 stellar-access = "0.7.2"
 stellar-macros = "0.7.2"
 stellar-tokens = "0.7.2"
-stellar-registry = "0.0.11"
+stellar-registry = "0.1.0"
 stellar-xdr = "26.0.1"
 
 [profile.release]


### PR DESCRIPTION
What
----

Fill in `.github/workflows/contract-release.yml` to actually create a GH
release for the `guess-the-number` contract.

Why
---

Because:

1. We, the Stellar Scaffold team, want to publish properly-structured
   versions of `guess-the-number` to Stellar Registry
   ("properly-structured" meaning SEP-55 adherence)
2. Our users benefit from a real example of how to set up one of these
   workflow files, rather than a poorly-filled in placeholder

Why not for the OZ contracts?
-----------------------------

They are already handled by https://github.com/stellar-registry/oz-combined-wasms

Dangers & Alternatives
----------------------

It's possible downstream consumers of Stellar Scaffold will also try to
publish/deploy the `guess-the-number` wasm/contract by using this workflow.

As long as we beat them to it, they shouldn't be able to.

And also, we hold the keys to putting `guess-the-number` in the root
Registry, rather than `unverified/guess-the-number`. They do not.

Even if there are multiple versions of this wasm/contract that end up in
Registry and/or Stellar.Expert, that's fine. It's a silly toy example.